### PR TITLE
Use pandas util

### DIFF
--- a/pandas_hash/pandas_hash.py
+++ b/pandas_hash/pandas_hash.py
@@ -2,30 +2,36 @@ import pandas as pd
 from hashlib import sha256
 from pandas.util import hash_pandas_object
 
+class PandasWrapper:
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __hash__(self):
+        return hash((
+            int(sha256(hash_pandas_object(self.obj).values).hexdigest(), 16),
+            hash(self.obj.index.name),
+            hash(self.obj.columns.name)
+        ))
+
+
 def convert_hashable(obj):
     try:
         hash(obj)
     except TypeError:
         if type(obj) is list:
-            return tuple(convert_hashable(i) for i in obj)
+            return (list, tuple(convert_hashable(i) for i in obj))
         elif type(obj) is set:
-            return frozenset(convert_hashable(i) for i in obj)
+            return (set, frozenset(convert_hashable(i) for i in obj))
         elif type(obj) is dict:
-            return frozenset((convert_hashable(k), convert_hashable(v)) for k,v in obj.items())
-        elif hasattr(obj, '__dict__'):
-            return convert_hashable(obj.__dict__)
+            return (dict, frozenset((convert_hashable(k), convert_hashable(v)) for k,v in obj.items()))
+        elif isinstance(obj, pd.DataFrame):
+            return PandasWrapper(obj)
+        else:
+            raise TypeError(f"Don't know how to convert object of type {type(obj)} to hashable")
+        # elif hasattr(obj, '__dict__'):
+            # return convert_hashable(obj.__dict__)
     else:
         return obj
 
 def hash_object(obj):
-    try:
-        return hash(obj)
-    except TypeError:
-        if isinstance(obj, pd.DataFrame):
-            return (
-                sha256(hash_pandas_object(obj).values).hexdigest() + 
-                hex(hash(obj.index.name))[2:] + 
-                hex(hash(obj.columns.name))[2:]
-            )
-        else:
-            return hash(type(obj)) ^ hash(convert_hashable(obj))
+        return hash(convert_hashable(obj))

--- a/pandas_hash/pandas_hash.py
+++ b/pandas_hash/pandas_hash.py
@@ -19,19 +19,20 @@ def convert_hashable(obj):
         hash(obj)
     except TypeError:
         if type(obj) is list:
-            return (list, tuple(convert_hashable(i) for i in obj))
+            out_obj = tuple(convert_hashable(i) for i in obj)
         elif type(obj) is set:
-            return (set, frozenset(convert_hashable(i) for i in obj))
+            out_obj = frozenset(convert_hashable(i) for i in obj)
         elif type(obj) is dict:
-            return (dict, frozenset((convert_hashable(k), convert_hashable(v)) for k,v in obj.items()))
+            out_obj = frozenset((convert_hashable(k), convert_hashable(v)) for k,v in obj.items())
         elif isinstance(obj, pd.DataFrame):
-            return PandasWrapper(obj)
+            out_obj = PandasWrapper(obj)
         else:
             raise TypeError(f"Don't know how to convert object of type {type(obj)} to hashable")
         # elif hasattr(obj, '__dict__'):
             # return convert_hashable(obj.__dict__)
+        return out_obj
     else:
         return obj
 
 def hash_object(obj):
-        return hash(convert_hashable(obj))
+    return hash((type(obj), convert_hashable(obj)))

--- a/pandas_hash/pandas_hash.py
+++ b/pandas_hash/pandas_hash.py
@@ -23,7 +23,7 @@ def convert_hashable(obj):
         elif type(obj) is set:
             out_obj = frozenset(convert_hashable(i) for i in obj)
         elif type(obj) is dict:
-            out_obj = frozenset((convert_hashable(k), convert_hashable(v)) for k,v in obj.items())
+            out_obj = frozenset((k, convert_hashable(v)) for k,v in obj.items())
         elif isinstance(obj, pd.DataFrame):
             out_obj = PandasWrapper(obj)
         else:

--- a/pandas_hash/pandas_hash.py
+++ b/pandas_hash/pandas_hash.py
@@ -2,7 +2,7 @@ import pandas as pd
 from hashlib import sha256
 from pandas.util import hash_pandas_object
 
-class PandasWrapper:
+class PandasDataFrameWrapper:
     def __init__(self, obj):
         self.obj = obj
 
@@ -25,7 +25,7 @@ def convert_hashable(obj):
         elif type(obj) is dict:
             out_obj = frozenset((k, convert_hashable(v)) for k,v in obj.items())
         elif isinstance(obj, pd.DataFrame):
-            out_obj = PandasWrapper(obj)
+            out_obj = PandasDataFrameWrapper(obj)
         else:
             raise TypeError(f"Don't know how to convert object of type {type(obj)} to hashable")
         # elif hasattr(obj, '__dict__'):

--- a/pandas_hash/pandas_hash.py
+++ b/pandas_hash/pandas_hash.py
@@ -1,4 +1,6 @@
 import pandas as pd
+from hashlib import sha256
+from pandas.util import hash_pandas_object
 
 def convert_hashable(obj):
     try:
@@ -19,4 +21,11 @@ def hash_object(obj):
     try:
         return hash(obj)
     except TypeError:
-        return hash(type(obj)) ^ hash(convert_hashable(obj))
+        if isinstance(obj, pd.DataFrame):
+            return (
+                sha256(hash_pandas_object(obj).values).hexdigest() + 
+                hex(hash(obj.index.name))[2:] + 
+                hex(hash(obj.columns.name))[2:]
+            )
+        else:
+            return hash(type(obj)) ^ hash(convert_hashable(obj))

--- a/tests/hash_test.py
+++ b/tests/hash_test.py
@@ -21,9 +21,12 @@ class TestHash(unittest.TestCase):
         self.assertNotEqual(hash_object(frozenset((1, 2))), hsh)
         
     def test_hash_pandas(self):
-        hsh = hash_object(pd.DataFrame(dict(column1=[1, 3, 5], column2=[2, 3, 5], name='hello')))
+        df = pd.DataFrame(dict(column1=[1, 3, 5], column2=[2, 3, 5], name='hello'))
+        hsh = hash_object(df)
         hsh2 = hash_object(pd.DataFrame(dict(column1=[1, 3, 5], column2=[2, 3, 5], name='hello2')))
         self.assertTrue(hsh)
         print(hsh)
         print(hsh2)
         self.assertNotEqual(hsh, hsh2)
+        self.assertNotEqual(hsh, hash_object(df.rename_axis('newindex', axis=0)))
+        self.assertNotEqual(hsh, hash_object(df.rename_axis('newcolumns', axis=1)))

--- a/tests/hash_test.py
+++ b/tests/hash_test.py
@@ -25,9 +25,12 @@ class TestHash(unittest.TestCase):
         self.assertTrue(hsh)
         self.assertNotEqual(hash(convert_hashable(obj)), hsh)
 
+    def test_hash_dict(self):
+        obj = dict(a='hello', b='there')
+        hsh = hash_object(obj)
         self.assertTrue(hsh)
-        self.assertNotEqual(hash_object(frozenset((1, 2))), hsh)
-        
+        self.assertNotEqual(hash(convert_hashable(obj)), hsh)
+
     def test_hash_pandas(self):
         df = pd.DataFrame(dict(column1=[1, 3, 5], column2=[2, 3, 5], name='hello'))
         hsh = hash_object(df)

--- a/tests/hash_test.py
+++ b/tests/hash_test.py
@@ -15,27 +15,28 @@ class TestHash(unittest.TestCase):
 
     def test_hash_list(self):
         obj = [1, 2]
-        hsh = hash_object(obj)
-        self.assertTrue(hsh)
-        self.assertNotEqual(hash(convert_hashable(obj)), hsh)
+        obj_rev = list(reversed(obj))
+        self.assertTrue(hash_object(obj))
+        self.assertNotEqual(hash(convert_hashable(obj)), hash_object(obj))
+        self.assertNotEqual(hash_object(obj), hash_object(obj_rev))
 
     def test_hash_set(self):
         obj = {1, 2}
-        hsh = hash_object(obj)
-        self.assertTrue(hsh)
-        self.assertNotEqual(hash(convert_hashable(obj)), hsh)
+        self.assertTrue(hash_object(obj))
+        self.assertNotEqual(hash(convert_hashable(obj)), hash_object(obj))
 
     def test_hash_dict(self):
         obj = dict(a='hello', b='there')
-        hsh = hash_object(obj)
-        self.assertTrue(hsh)
-        self.assertNotEqual(hash(convert_hashable(obj)), hsh)
+        obj_rev = dict(b='there', a='hello')
+        self.assertTrue(hash_object(obj))
+        self.assertNotEqual(hash(convert_hashable(obj)), hash_object(obj))
+        # For now I guess differently ordered dicts should be hashed the same
+        self.assertEqual(hash_object(obj), hash_object(obj_rev)) 
 
     def test_hash_pandas(self):
         df = pd.DataFrame(dict(column1=[1, 3, 5], column2=[2, 3, 5], name='hello'))
-        hsh = hash_object(df)
-        hsh2 = hash_object(pd.DataFrame(dict(column1=[1, 3, 5], column2=[2, 3, 5], name='hello2')))
-        self.assertTrue(hsh)
-        self.assertNotEqual(hsh, hsh2)
-        self.assertNotEqual(hsh, hash_object(df.rename_axis('newindex', axis=0)))
-        self.assertNotEqual(hsh, hash_object(df.rename_axis('newcolumns', axis=1)))
+        df2 = pd.DataFrame(dict(column1=[1, 3, 5], column2=[2, 3, 5], name='hello2'))
+        self.assertTrue(hash_object(df))
+        self.assertNotEqual(hash_object(df), hash_object(df2))
+        self.assertNotEqual(hash_object(df), hash_object(df.rename_axis('newindex', axis=0)))
+        self.assertNotEqual(hash_object(df), hash_object(df.rename_axis('newcolumns', axis=1)))

--- a/tests/hash_test.py
+++ b/tests/hash_test.py
@@ -7,16 +7,24 @@ import os
 class TestHash(unittest.TestCase):
 
     def test_hash_hashable(self):
-        self.assertEqual(hash_object((1, 2)), hash((1, 2)))
-        self.assertEqual(hash_object(frozenset((1, 2))), hash(frozenset((1, 2))))
+        obj = (1, 2)
+        rev_tuple = (2, 1)
+        self.assertTrue(hash_object(obj))
+        self.assertNotEqual(hash_object(obj), hash_object(rev_tuple))
+        self.assertTrue(hash_object(frozenset(obj)))
 
     def test_hash_list(self):
-        hsh = hash_object([1, 2])
+        obj = [1, 2]
+        hsh = hash_object(obj)
         self.assertTrue(hsh)
-        self.assertNotEqual(hash_object((1, 2)), hsh)
+        self.assertNotEqual(hash(convert_hashable(obj)), hsh)
 
     def test_hash_set(self):
-        hsh = hash_object({1, 2})
+        obj = {1, 2}
+        hsh = hash_object(obj)
+        self.assertTrue(hsh)
+        self.assertNotEqual(hash(convert_hashable(obj)), hsh)
+
         self.assertTrue(hsh)
         self.assertNotEqual(hash_object(frozenset((1, 2))), hsh)
         

--- a/tests/hash_test.py
+++ b/tests/hash_test.py
@@ -36,8 +36,6 @@ class TestHash(unittest.TestCase):
         hsh = hash_object(df)
         hsh2 = hash_object(pd.DataFrame(dict(column1=[1, 3, 5], column2=[2, 3, 5], name='hello2')))
         self.assertTrue(hsh)
-        print(hsh)
-        print(hsh2)
         self.assertNotEqual(hsh, hsh2)
         self.assertNotEqual(hsh, hash_object(df.rename_axis('newindex', axis=0)))
         self.assertNotEqual(hsh, hash_object(df.rename_axis('newcolumns', axis=1)))

--- a/tests/hash_test.py
+++ b/tests/hash_test.py
@@ -2,8 +2,6 @@ import unittest
 import pandas as pd
 from pandas_hash.pandas_hash import convert_hashable, hash_object
 
-import os
-
 class TestHash(unittest.TestCase):
 
     def test_hash_hashable(self):


### PR DESCRIPTION
Switched to using pandas.util instead of relying on the class __dict__. The data stored by the dataframe in the dict in the '_mgr' key as a BlockManager is hashable, but the hash apparently doesn't depend on the stored data. This could be worked around using special cases, but it seems more reasonable to build a special case around existing library functions.